### PR TITLE
Fix boundary check for device data with "data" and "tlv8" units

### DIFF
--- a/src/boundaries/hap.ts
+++ b/src/boundaries/hap.ts
@@ -1,6 +1,6 @@
 import z from 'zod'
 
-const NumberAlikeTypesTypesBoundary = z.union([
+const NumericTypesBoundary = z.union([
     z.literal('bool'),
     z.literal('float'),
     z.literal('int'),
@@ -9,17 +9,19 @@ const NumberAlikeTypesTypesBoundary = z.union([
     z.literal('uint32'),
     z.literal('uint64'),
 ])
-export type NumberAlikeTypes = z.infer<typeof NumberAlikeTypesTypesBoundary>
+export type NumericTypes = z.infer<typeof NumericTypesBoundary>
 
 export const CharacteristicBoundary = z.intersection(
     z.object({ type: z.string(), description: z.string() }),
     z.union([
         z.object({
-            format: NumberAlikeTypesTypesBoundary,
+            format: NumericTypesBoundary,
             value: z.optional(z.number()),
             unit: z.optional(z.string()),
         }),
         z.object({ format: z.literal('string'), value: z.string() }),
+        z.object({ format: z.literal('data'), value: z.optional(z.string()) }),
+        z.object({ format: z.literal('tlv8'), value: z.string(z.string()) }),
     ]),
 )
 export type Characteristic = z.infer<typeof CharacteristicBoundary>

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -32,6 +32,8 @@ export function aggregate(devices: Device[], timestamp: Date): Metric[] {
                     const format = characteristic.format
                     switch (format) {
                         case 'string':
+                        case 'tlv8':
+                        case 'data':
                             break
 
                         case 'bool':

--- a/tests/aggregator.test.ts
+++ b/tests/aggregator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { DeviceBoundary } from '../src/boundaries/hap'
+import { DeviceBoundary } from '../src/boundaries'
 import { Metric, aggregate } from '../src/metrics'
 import dysonData from './fixtures/dyson.json'
 import emptyData from './fixtures/empty.json'


### PR DESCRIPTION
The type did not support "data" and "tlv8" which are part of the spec so this fixes it. Fixes #7