### PR TITLE
Integration tests for the fastify HTTP adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "devDependencies": {
                 "@jest/globals": "^29.3.0",
                 "@types/node": "^18.11.9",
+                "@types/supertest": "^2.0.12",
                 "@typescript-eslint/eslint-plugin": "^5.42.0",
                 "@typescript-eslint/parser": "^5.42.0",
                 "eslint": "^8.0.1",
@@ -29,6 +30,7 @@
                 "nodemon": "^2.0.13",
                 "prettier": "^2.7.1",
                 "rimraf": "^3.0.2",
+                "supertest": "^6.3.1",
                 "ts-jest": "^29.0.3",
                 "ts-node": "^10.3.0",
                 "typescript": "^4.4.4"
@@ -1423,6 +1425,12 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "node_modules/@types/cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+            "dev": true
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1491,6 +1499,25 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "node_modules/@types/superagent": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.15.tgz",
+            "integrity": "sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/cookiejar": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/supertest": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+            "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/superagent": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.13",
@@ -1928,6 +1955,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true
         },
         "node_modules/asn1": {
             "version": "0.2.6",
@@ -2458,6 +2491,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2477,6 +2516,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/cookiejar": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+            "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+            "dev": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.2",
@@ -2615,6 +2660,16 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+            "dev": true,
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
             }
         },
         "node_modules/diff": {
@@ -3423,6 +3478,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "node_modules/fast-srp-hap": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
@@ -3574,6 +3635,33 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/formidable": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+            "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+            "dev": true,
+            "dependencies": {
+                "dezalgo": "1.0.3",
+                "hexoid": "1.0.0",
+                "once": "1.4.0",
+                "qs": "6.9.3"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/tunnckoCore/commissions"
+            }
+        },
+        "node_modules/formidable/node_modules/qs": {
+            "version": "6.9.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+            "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/forwarded": {
@@ -3971,6 +4059,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hexoid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/hexy": {
@@ -5448,6 +5545,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -5459,6 +5565,18 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/mime-db": {
@@ -6864,6 +6982,69 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/superagent": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.3.tgz",
+            "integrity": "sha512-oBC+aNsCjzzjmO5AOPBPFS+Z7HPzlx+DQr/aHwM08kI+R24gsDmAS1LMfza1fK+P+SKlTAoNZpOvooE/pRO1HA==",
+            "dev": true,
+            "dependencies": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.3",
+                "debug": "^4.3.4",
+                "fast-safe-stringify": "^2.1.1",
+                "form-data": "^4.0.0",
+                "formidable": "^2.0.1",
+                "methods": "^1.1.2",
+                "mime": "2.6.0",
+                "qs": "^6.11.0",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=6.4.0 <13 || >=14"
+            }
+        },
+        "node_modules/superagent/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/superagent/node_modules/qs": {
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "dev": true,
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/supertest": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.1.tgz",
+            "integrity": "sha512-hRohNeIfk/cA48Cxpa/w48hktP6ZaRqXb0QV5rLvW0C7paRsBU3Q5zydzYrslOJtj/gd48qx540jKtcs6vG1fQ==",
+            "dev": true,
+            "dependencies": {
+                "methods": "^1.1.2",
+                "superagent": "^8.0.3"
+            },
+            "engines": {
+                "node": ">=6.4.0"
             }
         },
         "node_modules/supports-color": {
@@ -8656,6 +8837,12 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+            "dev": true
+        },
         "@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8724,6 +8911,25 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "@types/superagent": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.15.tgz",
+            "integrity": "sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==",
+            "dev": true,
+            "requires": {
+                "@types/cookiejar": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/supertest": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+            "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+            "dev": true,
+            "requires": {
+                "@types/superagent": "*"
+            }
         },
         "@types/yargs": {
             "version": "17.0.13",
@@ -9007,6 +9213,12 @@
                 "es-abstract": "^1.20.4",
                 "es-shim-unscopables": "^1.0.0"
             }
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true
         },
         "asn1": {
             "version": "0.2.6",
@@ -9394,6 +9606,12 @@
             "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
             "dev": true
         },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9410,6 +9628,12 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
             "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        },
+        "cookiejar": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+            "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -9514,6 +9738,16 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
+        },
+        "dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+            "dev": true,
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
         },
         "diff": {
             "version": "4.0.2",
@@ -10144,6 +10378,12 @@
             "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
             "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
         },
+        "fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "fast-srp-hap": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
@@ -10268,6 +10508,26 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "formidable": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+            "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+            "dev": true,
+            "requires": {
+                "dezalgo": "1.0.3",
+                "hexoid": "1.0.0",
+                "once": "1.4.0",
+                "qs": "6.9.3"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.9.3",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+                    "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+                    "dev": true
+                }
             }
         },
         "forwarded": {
@@ -10556,6 +10816,12 @@
             "requires": {
                 "has-symbols": "^1.0.2"
             }
+        },
+        "hexoid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+            "dev": true
         },
         "hexy": {
             "version": "0.2.11",
@@ -11651,6 +11917,12 @@
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true
         },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+            "dev": true
+        },
         "micromatch": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -11660,6 +11932,12 @@
                 "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
             }
+        },
+        "mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.52.0",
@@ -12684,6 +12962,56 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
+        },
+        "superagent": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.3.tgz",
+            "integrity": "sha512-oBC+aNsCjzzjmO5AOPBPFS+Z7HPzlx+DQr/aHwM08kI+R24gsDmAS1LMfza1fK+P+SKlTAoNZpOvooE/pRO1HA==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.3",
+                "debug": "^4.3.4",
+                "fast-safe-stringify": "^2.1.1",
+                "form-data": "^4.0.0",
+                "formidable": "^2.0.1",
+                "methods": "^1.1.2",
+                "mime": "2.6.0",
+                "qs": "^6.11.0",
+                "semver": "^7.3.8"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "qs": {
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+                    "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+                    "dev": true,
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
+                }
+            }
+        },
+        "supertest": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.1.tgz",
+            "integrity": "sha512-hRohNeIfk/cA48Cxpa/w48hktP6ZaRqXb0QV5rLvW0C7paRsBU3Q5zydzYrslOJtj/gd48qx540jKtcs6vG1fQ==",
+            "dev": true,
+            "requires": {
+                "methods": "^1.1.2",
+                "superagent": "^8.0.3"
+            }
         },
         "supports-color": {
             "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "devDependencies": {
         "@jest/globals": "^29.3.0",
         "@types/node": "^18.11.9",
+        "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint": "^8.0.1",
@@ -45,6 +46,7 @@
         "nodemon": "^2.0.13",
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
+        "supertest": "^6.3.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.3.0",
         "typescript": "^4.4.4"

--- a/src/adapters/http/fastify.ts
+++ b/src/adapters/http/fastify.ts
@@ -6,18 +6,20 @@ function adaptResponseToReply(response: HttpResponse, reply: FastifyReply): void
     if (response.statusCode) {
         void reply.code(response.statusCode)
     }
-    if (response.body) {
-        void reply.send(response.body)
-    }
 
     if (response.headers) {
         void reply.headers(response.headers)
+    }
+
+    if (response.body) {
+        void reply.send(response.body)
     }
 }
 
 export const serve: HttpAdapter = async (server: HttpServer) => {
     const fastify = Fastify({
         logger: server.debug,
+        serverFactory: server.serverFactory,
     })
 
     fastify.addHook('onRequest', (request: FastifyRequest, reply: FastifyReply, next: HookHandlerDoneFunction) => {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,11 +1,13 @@
 import { HttpResponse } from './adapters/http/api'
 import { Metric } from './metrics'
 import { Logger } from 'homebridge'
+import { RequestListener, Server } from 'http'
 
 export interface HttpServer {
     port: number
     debug: boolean
-    log: Logger
+    log?: Logger
+    serverFactory?: (requestListener: RequestListener) => Server
     onRequest(): HttpResponse | undefined
     onMetrics(): HttpResponse
     onNotFound(): HttpResponse

--- a/tests/adapters/http/fastify.test.ts
+++ b/tests/adapters/http/fastify.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from '@jest/globals'
+import request from 'supertest'
+import { PrometheusServer } from '../../../src/prometheus'
+import { serve } from '../../../src/adapters/http/fastify'
+import { Server, createServer } from 'http'
+import { HttpServer } from '../../../src/http'
+import { Metric } from '../../../src/metrics'
+
+class TestablePrometheusServer extends PrometheusServer {
+    public serverFactory: HttpServer['serverFactory']
+}
+
+function createTestServer(): { http: Server; prometheus: HttpServer } {
+    const http = createServer()
+    const prometheus = new TestablePrometheusServer(0, undefined, false, 'homebridge')
+    prometheus.serverFactory = (handler) => http.on('request', handler)
+    serve(prometheus).catch((err: Error) => {
+        if (!('code' in err) || (err as unknown as { code: unknown }).code !== 'ERR_SERVER_ALREADY_LISTEN') {
+            console.debug(err)
+        }
+    })
+
+    return { http, prometheus }
+}
+
+describe('Fastify HTTP adapter', () => {
+    test('Serves 503 everywhere while metrics are not available', () => {
+        return request(createTestServer().http)
+            .get('/any-url')
+            .expect(503)
+            .expect('Content-Type', 'text/plain; charset=utf-8')
+            .expect('Retry-After', '15')
+            .expect('Metrics discovery pending')
+    })
+
+    test('Serves 404 on / when metrics are available', () => {
+        const testServer = createTestServer()
+        testServer.prometheus.updateMetrics([])
+
+        return request(testServer.http)
+            .get('/')
+            .expect(404)
+            .expect('Content-Type', 'text/plain; charset=utf-8')
+            .expect('Not found. Try /metrics')
+    })
+
+    test('Serves metrics', () => {
+        const testServer = createTestServer()
+        const timestamp = new Date('2020-01-01 00:00:00 UTC')
+        testServer.prometheus.updateMetrics([
+            new Metric('metric', 0.1, timestamp, { name: 'metric' }),
+            new Metric('total_something', 100, timestamp, { name: 'counter' }),
+        ])
+
+        return request(testServer.http)
+            .get('/metrics')
+            .expect(200)
+            .expect('Content-Type', 'text/plain; version=0.0.4')
+            .expect(
+                [
+                    '# TYPE homebridge_metric gauge',
+                    'homebridge_metric{name="metric"} 0.1 1577836800000',
+                    '# TYPE homebridge_something_total counter',
+                    'homebridge_something_total{name="counter"} 100 1577836800000',
+                ].join('\n'),
+            )
+    })
+})

--- a/tests/ambient.d.ts
+++ b/tests/ambient.d.ts
@@ -1,0 +1,6 @@
+import { SuperTest, Test } from 'supertest'
+import { Server } from 'http'
+
+declare module 'supertest' {
+    function supertest(app: Server): SuperTest<Test>
+}


### PR DESCRIPTION
Add integration tests for the *fastify* HTTP adapter. Fixes a bug where the order of method calls on the *fastify* `reply` object matters.

Uses *[supertest](https://www.npmjs.com/package/supertest)* for request matching.