### PR TITLE
Set charset in metrics content type

### DIFF
--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -34,7 +34,7 @@ export class MetricsRenderer {
 const retryAfterWhileDiscovery = 15
 const textContentType = 'text/plain; charset=utf-8'
 const prometheusSpecVersion = '0.0.4'
-const metricsContentType = `text/plain; version=${prometheusSpecVersion}`
+const metricsContentType = `${textContentType}; version=${prometheusSpecVersion}`
 
 function headers(contentType: string, headers: Record<string, string> = {}): Record<string, string> {
     return { ...headers, 'Content-Type': contentType }

--- a/tests/adapters/http/fastify.test.ts
+++ b/tests/adapters/http/fastify.test.ts
@@ -55,7 +55,7 @@ describe('Fastify HTTP adapter', () => {
         return request(testServer.http)
             .get('/metrics')
             .expect(200)
-            .expect('Content-Type', 'text/plain; version=0.0.4')
+            .expect('Content-Type', 'text/plain; charset=utf-8; version=0.0.4')
             .expect(
                 [
                     '# TYPE homebridge_metric gauge',


### PR DESCRIPTION
Send `Content-Type: text/plain; charset=utf-8; version=0.0.4` instead of `Content-Type: text/plain; version=0.0.4` so that special characters in names have a chance to work.