### PR TITLE
Strict type imports

### DIFF
--- a/src/adapters/discovery/api.ts
+++ b/src/adapters/discovery/api.ts
@@ -1,5 +1,5 @@
 import type { Device } from '../../boundaries/hap'
-import { Logger } from 'homebridge'
+import type { Logger } from 'homebridge'
 
 type Pin = string
 

--- a/src/adapters/discovery/hap_node_js_client.ts
+++ b/src/adapters/discovery/hap_node_js_client.ts
@@ -1,7 +1,7 @@
 import type { HapDiscover } from './api'
 import { HAPNodeJSClient } from 'hap-node-client'
 import { Device, DeviceBoundary, checkBoundary } from '../../boundaries'
-import { Logger } from 'homebridge'
+import type { Logger } from 'homebridge'
 import z from 'zod'
 
 const MaybeDevices = z.array(z.unknown())

--- a/src/adapters/http/api.ts
+++ b/src/adapters/http/api.ts
@@ -1,4 +1,4 @@
-import { HttpServer } from '../../http'
+import type { HttpServer } from '../../http'
 
 export interface HttpResponse {
     statusCode?: number

--- a/src/adapters/http/fastify.ts
+++ b/src/adapters/http/fastify.ts
@@ -1,6 +1,6 @@
 import Fastify, { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
-import { HttpAdapter, HttpResponse } from './api'
-import { HttpServer } from '../../http'
+import type { HttpAdapter, HttpResponse } from './api'
+import type { HttpServer } from '../../http'
 
 function adaptResponseToReply(response: HttpResponse, reply: FastifyReply): void {
     if (response.statusCode) {

--- a/src/boundaries/checker.ts
+++ b/src/boundaries/checker.ts
@@ -1,4 +1,4 @@
-import z from 'zod'
+import type z from 'zod'
 
 type Path = (string | number)[]
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from './adapters/http/api'
-import { Metric } from './metrics'
-import { Logger } from 'homebridge'
-import { RequestListener, Server } from 'http'
+import type { HttpResponse } from './adapters/http/api'
+import type { Metric } from './metrics'
+import type { Logger } from 'homebridge'
+import type { RequestListener, Server } from 'http'
 
 export interface HttpServer {
     port: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { API } from 'homebridge'
+import type { API } from 'homebridge'
 
 import { PLATFORM_NAME } from './settings'
 import { PrometheusExporterPlatform } from './platform'

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,9 +1,9 @@
-import { API, IndependentPlatformPlugin, Logger, PlatformConfig } from 'homebridge'
+import type { API, IndependentPlatformPlugin, Logger, PlatformConfig } from 'homebridge'
 
 import { aggregate } from './metrics'
 import { discover } from './adapters/discovery/hap_node_js_client'
 import { serve } from './adapters/http/fastify'
-import { HttpServerController } from './adapters/http/api'
+import type { HttpServerController } from './adapters/http/api'
 import { PrometheusServer } from './prometheus'
 import { Config, ConfigBoundary, checkBoundary } from './boundaries'
 

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -1,7 +1,7 @@
-import { Metric } from './metrics'
-import { Logger } from 'homebridge'
-import { HttpResponse } from './adapters/http/api'
-import { HttpServer } from './http'
+import type { Metric } from './metrics'
+import type { Logger } from 'homebridge'
+import type { HttpResponse } from './adapters/http/api'
+import type { HttpServer } from './http'
 
 export class MetricsRenderer {
     constructor(private readonly prefix: string) {}

--- a/tests/adapters/http/fastify.test.ts
+++ b/tests/adapters/http/fastify.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest'
 import { PrometheusServer } from '../../../src/prometheus'
 import { serve } from '../../../src/adapters/http/fastify'
 import { Server, createServer } from 'http'
-import { HttpServer } from '../../../src/http'
+import type { HttpServer } from '../../../src/http'
 import { Metric } from '../../../src/metrics'
 
 class TestablePrometheusServer extends PrometheusServer {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "rootDir": "./",
         "strict": true,
         "esModuleInterop": true,
+        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "resolveJsonModule": true
     },


### PR DESCRIPTION
When a symbols is only used as a type, require `import type {…}`