### PR TITLE
Unpin and upgrade jest-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6897,14 +6897,14 @@
             }
         },
         "node_modules/jest-mock": {
-            "version": "29.2.2",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.2.tgz",
-            "integrity": "sha512-1leySQxNAnivvbcx0sCB37itu8f4OX2S/+gxLAV4Z62shT4r4dTG9tACDywUAEZoLSr36aYUTsVp3WKwWt4PMQ==",
+            "version": "29.3.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
+            "integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.2.1",
+                "@jest/types": "^29.3.1",
                 "@types/node": "*",
-                "jest-util": "^29.2.1"
+                "jest-util": "^29.3.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -11720,7 +11720,7 @@
                 "@jest/fake-timers": "^29.3.1",
                 "@jest/types": "^29.3.1",
                 "@types/node": "*",
-                "jest-mock": "29.2"
+                "jest-mock": "^29.3.1"
             }
         },
         "@jest/expect": {
@@ -11752,7 +11752,7 @@
                 "@sinonjs/fake-timers": "^9.1.2",
                 "@types/node": "*",
                 "jest-message-util": "^29.3.1",
-                "jest-mock": "29.2",
+                "jest-mock": "^29.3.1",
                 "jest-util": "^29.3.1"
             }
         },
@@ -11765,7 +11765,7 @@
                 "@jest/environment": "^29.3.1",
                 "@jest/expect": "^29.3.1",
                 "@jest/types": "^29.3.1",
-                "jest-mock": "29.2"
+                "jest-mock": "^29.3.1"
             }
         },
         "@jest/reporters": {
@@ -15963,7 +15963,7 @@
                 "@jest/fake-timers": "^29.3.1",
                 "@jest/types": "^29.3.1",
                 "@types/node": "*",
-                "jest-mock": "29.2",
+                "jest-mock": "^29.3.1",
                 "jest-util": "^29.3.1"
             }
         },
@@ -16033,14 +16033,14 @@
             }
         },
         "jest-mock": {
-            "version": "29.2.2",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.2.tgz",
-            "integrity": "sha512-1leySQxNAnivvbcx0sCB37itu8f4OX2S/+gxLAV4Z62shT4r4dTG9tACDywUAEZoLSr36aYUTsVp3WKwWt4PMQ==",
+            "version": "29.3.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.3.1.tgz",
+            "integrity": "sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.2.1",
+                "@jest/types": "^29.3.1",
                 "@types/node": "*",
-                "jest-util": "^29.2.1"
+                "jest-util": "^29.3.1"
             }
         },
         "jest-pnp-resolver": {
@@ -16145,7 +16145,7 @@
                 "graceful-fs": "^4.2.9",
                 "jest-haste-map": "^29.3.1",
                 "jest-message-util": "^29.3.1",
-                "jest-mock": "29.2",
+                "jest-mock": "^29.3.1",
                 "jest-regex-util": "^29.2.0",
                 "jest-resolve": "^29.3.1",
                 "jest-snapshot": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,5 @@
         "fastify": "^4.9.2",
         "hap-node-client": "^0.1.25",
         "zod": "^3.19.1"
-    },
-    "overrides": {
-        "jest-mock": "29.2"
     }
 }


### PR DESCRIPTION
Previously failed because of a type error deep in node_modules, let’s try again.