### PR TITLE
NPM v9 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - { node-version: 14.x, lint: true, tests: true }
-          - { node-version: 15.x, lint: true, tests: true }
+          - { node-version: 15.x, lint: false, tests: true }
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { node-version: 10.x, lint: false, tests: false }
-          - { node-version: 11.x, lint: false, tests: false }
-          - { node-version: 12.x, lint: false, tests: false }
-          - { node-version: 13.x, lint: false, tests: false }
           - { node-version: 14.x, lint: true, tests: true }
-          - { node-version: 15.x, lint: false, tests: true }
+          - { node-version: 15.x, lint: true, tests: true }
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     },
     "main": "dist/src/index.js",
     "scripts": {
-        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; `npm bin`/tsc --noEmit && `npm bin`/prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && `npm bin`/eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
+        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npx tsc --noEmit && npx prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && npx eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
         "start": "npm run build && npm run link && nodemon",
-        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npm run code-generation && `npm bin`/jest `ifNotCi --watchAll --collect-coverage`",
+        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npm run code-generation && npx jest `ifNotCi --watchAll --collect-coverage`",
         "link": "npm install --no-save file:///$PWD/",
         "build": "rimraf ./dist .tsbuildinfo && npm run code-generation && tsc",
         "code-generation": "./code-generation/hap-gen.js && ./code-generation/config-scheme-gen.js",


### PR DESCRIPTION
`npm bin` no longer exists in npm version 9, so we use `npx` to run local commands instead. `npm exec` would work as well, but that was only introduced with npx version 7 and node 14 uses version 6. Duh!