### PR TITLE
Update prometheus.ts (timestamp fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-prometheus-exporter",
-    "version": "1.0.5",
+    "version": "1.0.5-custom",
     "description": "Prometheus exporter for homebridge accessories.",
     "license": "Apache-2.0",
     "repository": {
@@ -10,11 +10,10 @@
     "bugs": {
         "url": "https://github.com/lstrojny/homebridge-prometheus-exporter/issues"
     },
-    "engines": {
-  "node": "^18.20.4 || ^20.15.1 || ^22",
-  "homebridge": "^1.8.0 || ^2.0.0"
-}
-    },
+"engines": {
+  "node": "^18 || ^20 || ^22 || ^24",
+  "homebridge": "^1.6.0 || ^2.0.0"
+},
     "main": "dist/src/index.js",
     "scripts": {
         "_portable_exec": "npmPortableExec() { `npm root`/.bin/$@; }; npmPortableExec",
@@ -36,28 +35,27 @@
     "devDependencies": {
         "@jest/globals": "^29.3.0",
         "@types/bcrypt": "^5.0.0",
-        "@types/node": "^20.2.3",
-        "@types/supertest": "^6.0.2",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^6.8.0",
-        "array.prototype.flatmap": "^1.3.1",
+        "@types/node": "^18.11.9",
+        "@types/supertest": "^2.0.12",
+        "@typescript-eslint/eslint-plugin": "^5.42.0",
+        "@typescript-eslint/parser": "^5.42.0",
         "eslint": "^8.0.1",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-prettier": "^5.0.1",
-        "hap-nodejs": "^0.12.0",
-        "homebridge": "^1.3.5",
+        "eslint-plugin-prettier": "^4.2.1",
+        "hap-nodejs": "^0.11.0",
+        "homebridge": "^2.0.0",
         "homebridge-cmdswitch2": "^0.2.10",
         "jest": "^29.3.0",
-        "json-schema-to-zod": "^2.0.12",
-        "nodemon": "^3.0.1",
-        "prettier": "^3.0.3",
-        "release-it": "^17.0.0",
-        "rimraf": "^5.0.0",
-        "supertest": "^7.0.0",
+        "json-schema-to-zod": "^0.6.0",
+        "nodemon": "^2.0.13",
+        "prettier": "^2.7.1",
+        "release-it": "^15.5.0",
+        "rimraf": "^3.0.2",
+        "supertest": "^6.3.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.3.0",
-        "typescript": "^5.0.2"
+        "typescript": "^4.4.4"
     },
     "dependencies": {
         "@fastify/auth": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-prometheus-exporter",
-    "version": "1.0.5-custom",
+    "version": "1.0.5",
     "description": "Prometheus exporter for homebridge accessories.",
     "license": "Apache-2.0",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
         "url": "https://github.com/lstrojny/homebridge-prometheus-exporter/issues"
     },
     "engines": {
-        "node": ">=14.18.1",
-        "homebridge": ">=1.3.5"
+  "node": "^18.20.4 || ^20.15.1 || ^22",
+  "homebridge": "^1.8.0 || ^2.0.0"
+}
     },
     "main": "dist/src/index.js",
     "scripts": {

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -69,11 +69,10 @@ export class PrometheusServer implements HttpServer {
         }
 
         return {
-            statusCode: 503,
-            headers: withHeaders(textContentType, { 'Retry-After': String(retryAfterWhileDiscovery) }),
-            body: 'Metrics discovery pending',
-        }
-    }
+    statusCode: 200,
+    headers: withHeaders(textContentType, {}),
+    body: '',
+}
 
     onMetrics(): HttpResponse {
         return {

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -25,11 +25,9 @@ export class MetricsRenderer {
         )
     }
 
-    private formatMetric(metric: Metric): string {
-        return `${this.metricName(metric.name)}${MetricsRenderer.renderLabels(metric.labels)} ${metric.value}${
-            metric.timestamp !== null ? ' ' + String(metric.timestamp.getTime()) : ''
-        }`
-    }
+private formatMetric(metric: Metric): string {
+    return `${this.metricName(metric.name)}${MetricsRenderer.renderLabels(metric.labels)} ${metric.value}`
+}
 
     private static renderLabels(labels: Metric['labels']): string {
         const rendered = Object.entries(labels)


### PR DESCRIPTION
Hi,  
I noticed an issues with DietPI and the latest Prometheus releases: long story short, I forgot to configure the time zone correctly on the first install, and occasionally the exporter stopped exporting data, but even after I corrected the time zone, the problems persisted. Every few hours, it stops export data without any notice, and then starts again. 

I discovered that by removing the exporter timestamp and using only Prometheus's timestamp, the issue disappeared.

Please verify everything and see if it's an improvement. Using the official Homebridge image for Raspberry PI, I never had this problem for years, it only appeared after switching to DietPI OS. Perhaps you can implement an option to choose between the exporter's timestamp or Prometheus's timestamp. It just a suggestion. 

Anyway thanks for the work with this plugin!